### PR TITLE
Adding in the capability to pass in a Socrata application token

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ An Opendatacache is available already at
 You should build the image locally, then you can run it:
 
     $ ./build.sh
-    $ WARM=1 APP_TOKEN=[Your Socrata App Token]./run.sh
+    $ WARM=1 APP_TOKEN=[Your Socrata App Token] ./run.sh
 
 OpenDataCache makes a lot of API requests, so you'll need to [sign up for an application token](http://dev.socrata.com/docs/app-tokens.html).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ An Opendatacache is available already at
 You should build the image locally, then you can run it:
 
     $ ./build.sh
-    $ WARM=1 ./run.sh
+    $ WARM=1 APP_TOKEN=[Your Socrata App Token]./run.sh
+
+OpenDataCache makes a lot of API requests, so you'll need to [sign up for an application token](http://dev.socrata.com/docs/app-tokens.html).
 
 #### A note on cache warming
 

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,7 @@ docker run -v $(pwd)/site:/opendatacache/site \
            -v $(pwd)/log:/var/log/opendatacache \
            -v $(pwd)/.aws:/root/.aws \
            -e "WARM=$WARM" \
+           -e "APP_TOKEN=$APP_TOKEN" \
            -d -i -p 80:8080  --name=opendatacache thegovlab/opendatacache /opendatacache/util/start.sh
 
 #WARM_URL=http://localhost:8080 

--- a/util/warm_dataset.sh
+++ b/util/warm_dataset.sh
@@ -32,7 +32,7 @@ wgetlog=$portallogs/api/views/$id/wget.log
 metadata_url=$proxy/$portal/api/views/${id}.json
 
 # obtain metadata about download
-metadata=$(curl -k -s -S --compressed "${metadata_url}" | tee $portallogs/api/views/$id/meta.json)
+metadata=$(curl --header "X-App-Token: $APP_TOKEN" -k -s -S --compressed "${metadata_url}" | tee $portallogs/api/views/$id/meta.json)
 columns="name attribution averageRating category createdAt description displayType downloadType downloadCount newBackend numberOfComments oid rowsUpdatedAt rowsUpdatedBy tableId totalTimesRated viewCount viewLastModified viewType tags"
 for key in $columns; do
   val=$(echo "$metadata" | grep "\"$key\" :" | head -n 1 | grep -Po ': .*' | tr -cd '[:print:]' | tr -d '\\' | sed -r 's/^: "?//' | sed -r 's/"?,$//' | tr -s '[:space:]' ' ')
@@ -102,7 +102,7 @@ fi
 tmpdir=/tmp/$portal/$id
 data_file=$tmpdir/data
 mkdir -p $tmpdir
-wget -S --header='Accept-Encoding: gzip' --progress=dot --no-check-certificate -O $data_file \
+wget -S --header "X-App-Token: $APP_TOKEN" --header='Accept-Encoding: gzip' --progress=dot --no-check-certificate -O $data_file \
   "$url" 2>${wgetlog}
 
 # measure the data


### PR DESCRIPTION
Over the next couple of months we'll be starting to more closely enforce our throttling limits for API consumers that aren't using application tokens, and OpenDataCache was flagged as one of the larger untokened consumers of our API.

Could you please register for an application token and set it up in your Docker env as I describe in the updated README? If you send me your app token, I'll make sure it gets whitelisted so you don't have to worry about exceeding any limits.

Also, you might want to check out our new [search API](http://labs.socrata.com/docs/search.html) or at least the [domain listing](http://labs.socrata.com/docs/search.html#-listing-domains). They may provide a more efficient way for you to update your dataset listing. 

Thanks! :+1: 
