### PR TITLE
Edmonton is in Alberta (AB), Canada, not California (CA)

### DIFF
--- a/site/static/js/opendatacache.js
+++ b/site/static/js/opendatacache.js
@@ -48,7 +48,7 @@ var portals2names = {
   "data.weatherfordtx.gov": "Weatherford, TX",
   "bronx.lehman.cuny.edu": "Lehman College",
   "data.sfgov.org": "San Francisco, CA",
-  "data.edmonton.ca": "Edmonton, CA",
+  "data.edmonton.ca": "Edmonton, AB",
   "data.consumerfinance.gov": "Consumer Financial Protection Bureau",
   "www.metrochicagodata.org": "Metro Chicago Data",
   "data.kingcounty.gov": "King County, WA",


### PR DESCRIPTION
In general, mixing ISO country codes with US postal codes is confusing. Either add "US" to all US locations (i.e. every row has an ISO country code), or use the country names (Canada) instead of ISO codes to avoid collisions.
